### PR TITLE
Update energy_day to work with energy dashboard

### DIFF
--- a/custom_components/apsystems/sensor.py
+++ b/custom_components/apsystems/sensor.py
@@ -37,7 +37,9 @@ SENSOR_POWER_MAX = "power_max_day"
 SENSOR_TIME = "date"
 
 # to move apsystems timestamp to UTC
-OFFSET_SECONDS = timedelta(hours=7).total_seconds()
+OFFSET_MS = (
+    timedelta(hours=7).total_seconds() / timedelta(milliseconds=1).total_seconds()
+)
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -218,9 +220,9 @@ class ApsystemsSensor(SensorEntity):
         timestamp = ap_data[index_time][-1]
 
         if value == timestamp:  # current attribute is the timestamp, so fix it
-            value = int(value) + OFFSET_SECONDS
+            value = int(value) + OFFSET_MS
             value = datetime.fromtimestamp(value / 1000)
-        timestamp = int(timestamp) + OFFSET_SECONDS
+        timestamp = int(timestamp) + OFFSET_MS
 
         self._attributes[EXTRA_TIMESTAMP] = timestamp
 
@@ -316,7 +318,7 @@ class APsystemsFetcher:
         else:
             # rules to check cache
             timestamp_event = (
-                int(self.cache["time"][-1]) + OFFSET_SECONDS
+                int(self.cache["time"][-1]) + OFFSET_MS
             )  # apsystems have 8h delayed in timestamp from UTC
             timestamp_now = int(round(time.time() * 1000))
             cache_time = 6 * 60 * 1000  # 6 minutes

--- a/info.md
+++ b/info.md
@@ -1,7 +1,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) [![apsystems](https://img.shields.io/github/v/release/bgbraga/homeassistant-apsystems.svg)](https://github.com/bgbraga/homeassistant-apsystems) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
 
 ##### Please contribute:
-[![Buy me a beer!](https://img.shields.io/badge/Buy%20me%20a%20beer!-%F0%9F%8D%BA-yellow.svg)](https://www.buymeacoffee.com/bgbraga)
+[![Buy me a beer!](https://img.shields.io/badge/Buy%20me%20a%20beer!-%F0%9F%8D%BA-yellow.svg)](https://www.paypal.com/donate/?hosted_button_id=RWTHA7XKSMSZC)
 
 ### Features:
 This component simplifies the integration of a APsystems inverter:


### PR DESCRIPTION
Update the device class and state_class so the integration can be used with HA's energy dashboard.

Additional improvements:
1. Format using `black`
1. Run `isort` on includes.
1. Add type hints in some places.
1. Remove unused includes.
2. Define `OFFSET_SECONDS` using `datetime.timedelta` to make the value and units clearer.
3. Sort globals by name
4. Use a `NamedTuple` for config metadata for attribute access to fields.
5. Use f-strings instead of `str.format()`